### PR TITLE
archiver: only store deviceID for hardlinks

### DIFF
--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -181,6 +181,12 @@ func (arch *Archiver) nodeFromFileInfo(snPath, filename string, fi os.FileInfo) 
 	if !arch.WithAtime {
 		node.AccessTime = node.ModTime
 	}
+	if node.Links == 1 || node.Type == "dir" {
+		// the DeviceID is only necessary for hardlinked files
+		// when using subvolumes or snapshots their deviceIDs tend to change which causes
+		// restic to upload new tree blobs
+		node.DeviceID = 0
+	}
 	// overwrite name to match that within the snapshot
 	node.Name = path.Base(snPath)
 	return node, errors.Wrap(err, "NodeFromFileInfo")

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -2186,6 +2186,7 @@ func TestMetadataChanged(t *testing.T) {
 	sn, node2 := snapshot(t, repo, fs, nil, "testfile")
 
 	// set some values so we can then compare the nodes
+	want.DeviceID = 0
 	want.Content = node2.Content
 	want.Path = ""
 	if len(want.ExtendedAttributes) == 0 {

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -39,7 +39,7 @@ type Node struct {
 	User               string              `json:"user,omitempty"`
 	Group              string              `json:"group,omitempty"`
 	Inode              uint64              `json:"inode,omitempty"`
-	DeviceID           uint64              `json:"device_id,omitempty"` // device id of the file, stat.st_dev
+	DeviceID           uint64              `json:"device_id,omitempty"` // device id of the file, stat.st_dev, only stored for hardlinks
 	Size               uint64              `json:"size,omitempty"`
 	Links              uint64              `json:"links,omitempty"`
 	LinkTarget         string              `json:"linktarget,omitempty"`


### PR DESCRIPTION
The deviceID can change e.g. when backing up from filesystem snapshot. It is only used for hardlink detection. Thus there it is not necessary to store it for everything else.